### PR TITLE
Change Rustup Action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -70,12 +70,10 @@ jobs:
 
             - if: ${{ steps.cache-rustup.outputs.cache-hit != 'true' }}
               name: Install Rust toolchain
-              uses: actions-rs/toolchain@v1
+              uses: moonrepo/setup-rust@v1
               with:
                 profile: minimal
-                toolchain: ${{ matrix.build.TOOLCHAIN }}
-                target: ${{ matrix.build.TARGET }}
-                override: true
+                targets: ${{ matrix.build.TARGET }}
             
             - name: Install dependencies
               run: |

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -96,12 +96,11 @@ jobs:
 
       - if: ${{ steps.cache-rustup.outputs.cache-hit != 'true' }}
         name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: moonrepo/setup-rust@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.build.TOOLCHAIN }}
-          target: ${{ matrix.build.TARGET }}
-          override: true
+          targets: ${{ matrix.build.TARGET }}
+          cache-target: release
 
       - name: Build ${{ matrix.build.TARGET }} Binary
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
to remove this warning
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```