### PR TITLE
18 json schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 
 ## What is it?
-Lil' Schemy is a cli tool that enables "code first" schema generation. Use it to generate an OpenApi v3.0 schema from your TypeScript project. Focus on building a well tested, functionally correct product, then tack on a schema.
+Lil' Schemy is a cli tool that enables "code first" schema generation. Use it to generate an OpenApi v3.1.x schema from your TypeScript project. Focus on building a well tested, functionally correct product, then tack on a schema.
 
 ## How It Works
 Lil' Schemy works by finding Lil' functions and types, generating schemas from relevant symbols found or referenced within them. By the way, you can use the CLI to generate a default `schemy-config.js`. First, you need to indicate which files contain your route handlers by updating `schemy-config.js` like this...
@@ -186,7 +186,7 @@ export interface Resolvable {
 
 ### OpenApiOptions
 `OpenApiOptions` tells Lil' Schemy to generate an OpenApi schema
-- **base**: A user defined OpenApi schema that will overlay the generated schema. The only required field is `openapi`, which is always version "3.0.3" (for now)
+- **base**: A user defined OpenApi schema that will overlay the generated schema. The only required field is `openapi`, which is always version "3.1.0" (for now)
 - **output** (optional): The filepath where Lil' Schemy should write the schema. It will not write the schema without this.
 - **entry**: an array of blob patterns describing the files containing http paths that need schemas.
 
@@ -206,8 +206,6 @@ const config = {
     openApi: {
         // All values in base take precedence over generated values.
         base: {
-            // The only supported version.
-            openapi: "3.0.3",
             info: {
                 title: "My Application",
                 version: "1.0.0"

--- a/README.md
+++ b/README.md
@@ -143,9 +143,28 @@ Commands:
 - **T**: The type of the parameter whose name is listed as a required property.
 
 ### LilSub<From, To>
-`LilSub` is a type that represents an object with some properties replaced by another object's properties.
+`LilSub` replaces your design time type with a desired schema type:
 - **From**: The type used during design time of your application.
-- **To**: The type used to generate an OpenApi schema.
+- **To**: The type used to generate an OpenApi schema.  
+"Why?" Let's say you have a request handler that returns a type that directly or indirectly references a type from a module that Schemy can't resolve. In that case, you can tell Schemy to use a different type that Schemy can resolve. In the example below, Schemy will not discover that the TS module `node:events` lives in the file `events.d.ts`.
+```TS
+// events.d.ts
+declare module 'node:events' {
+    import events = require('events');
+    export = events;
+}
+
+// stream.d.ts
+declare module stream {
+    import { EventEmitter, Abortable } from 'node:events';
+    // ...
+}
+
+// return type of route handler
+export interface Resolvable {
+    stream: LilSub<stream, Uint8Array>
+}
+```
 
 ### format
 `format` is a type that represents a format. It can be either a `StringFormat` or a `NumberFormat`.

--- a/native/src/open_api/factory.rs
+++ b/native/src/open_api/factory.rs
@@ -421,7 +421,7 @@ impl OpenApiFactory {
                     .defer_external_type(&source_file_name, schema_name.into(), &type_name);
             }
             Some(Declaration::Type { node: node_index }) => {
-                let schema = open_api.components.schema(schema_name);
+                let schema = open_api.components.schema_with_id(schema_name);
 
                 if let Some(node) = type_node.get(node_index) {
                     self.define_schema_details(schema, &node, file_path, false, &PathOptions::default());
@@ -548,7 +548,7 @@ impl OpenApiFactory {
         if let Some(deferred_type) = self.deferred_schemas.recognize_external_type(type_name, file_path) {
             match self.symbol_tables.get_root_declaration(file_path, &type_name) {
                 Some(Declaration::Type { node }) => {
-                    let schema = open_api.components.schema(&deferred_type.schema_name);
+                    let schema = open_api.components.schema_with_id(&deferred_type.schema_name);
 
                     let node = root.get(node).unwrap();
 

--- a/native/src/open_api/schema.rs
+++ b/native/src/open_api/schema.rs
@@ -46,6 +46,10 @@ impl ApiComponents {
         self.schemas.entry(name.to_string()).or_insert(ApiSchema::new())
     }
 
+    pub fn schema_with_id(&mut self, name: &str) -> &mut ApiSchema {
+        self.schemas.entry(name.to_string()).or_insert(ApiSchema::with_id(name))
+    }
+
     pub(crate) fn contains_schema(&self, type_name: &str) -> bool {
         self.schemas.contains_key(type_name)
     }
@@ -235,6 +239,7 @@ pub struct ApiSchema {
     data_type: Option<String>,
     enums: Option<Vec<String>>,
     format: Option<String>,
+    id: Option<String>,
     is_example: bool,
     items: Option<Box<ApiSchema>>,
     properties: Option<HashMap<String, ApiSchema>>,
@@ -247,7 +252,7 @@ impl Serialize for ApiSchema {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("ApiSchema", 5)?;
+        let mut state = serializer.serialize_struct("ApiSchema", 10)?;
 
         if let Some(ref any_of) = self.any_of {
             state.serialize_field("anyOf", any_of)?;
@@ -260,6 +265,9 @@ impl Serialize for ApiSchema {
         }
         if let Some(ref format) = self.format {
             state.serialize_field("format", format)?;
+        }
+        if let Some(ref id) = self.id {
+            state.serialize_field("$id", &format!("#/components/schemas/{id}"))?;
         }
         if let Some(ref items) = self.items {
             state.serialize_field("items", items)?;
@@ -289,6 +297,23 @@ impl Serialize for ApiSchema {
 impl ApiSchema {
     pub fn new() -> Self {
         ApiSchema {
+            any_of: None,
+            all_of: None,
+            data_type: None,
+            enums: None,
+            format: None,
+            id: None,
+            is_example: false,
+            items: None,
+            properties: None,
+            reference: None,
+            required: HashSet::new(),
+        }
+    }
+
+    pub fn with_id(id: &str) -> Self {
+        ApiSchema {
+            id: Some(id.to_string()),
             any_of: None,
             all_of: None,
             data_type: None,

--- a/native/src/open_api/schema.rs
+++ b/native/src/open_api/schema.rs
@@ -14,7 +14,7 @@ pub struct OpenApi {
 impl OpenApi {
     pub fn new() -> Self {
         OpenApi {
-            open_api: "3.0.1".to_string(),
+            open_api: "3.1.0".to_string(),
             components: ApiComponents::new(),
             paths: HashMap::new(),
         }

--- a/src/commands/default-config.txt
+++ b/src/commands/default-config.txt
@@ -2,8 +2,6 @@ module.exports = {
     openApi: {
         // All values in base take precedence over generated values.
         base: {
-            // The only supported version.
-            openapi: "3.0.3",
             info: {
                 title: "DEFAULT APPLICATION TITLE",
                 version: "0.0.0"

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -23,7 +23,7 @@ describe('cli', function () {
 
         const config: LilSchemyOptions = (await import(rootConfigPath)).default;
 
-        expect(config.openApi?.base.openapi).to.eq("3.0.3");
+        expect(config.openApi?.base.info.version).to.eq("0.0.0");
     })
 
     it('writes configuration to user defined directory', async () => {
@@ -33,6 +33,6 @@ describe('cli', function () {
 
         const config: LilSchemyOptions = (await import(customConfigPath)).default;
 
-        expect(config.openApi?.base.openapi).to.eq("3.0.3");
+        expect(config.openApi?.base.info.version).to.eq("0.0.0");
     })
 })

--- a/tests/paths.spec.ts
+++ b/tests/paths.spec.ts
@@ -27,6 +27,7 @@ describe('open api generator', () => {
     it('generates schemas', () => {
         expect(schema.components?.schemas).to.deep.equalInAnyOrder({
             Account: {
+                $id: "#/components/schemas/Account",
                 properties: {
                     number: {
                         type: "string"
@@ -35,6 +36,7 @@ describe('open api generator', () => {
                 type: "object"
             },
             AdminUser: {
+                $id: "#/components/schemas/AdminUser",
                 properties: {
                     name: {
                         type: "string"
@@ -49,6 +51,7 @@ describe('open api generator', () => {
                 type: "object"
             },
             Registration: {
+                $id: "#/components/schemas/Registration",
                 properties: {
                     date: {
                         type: "string"
@@ -57,6 +60,7 @@ describe('open api generator', () => {
                 type: "object"
             },
             CreateUserRequest: {
+                $id: "#/components/schemas/CreateUserRequest",
                 properties: {
                     name: {
                         type: "string"
@@ -65,6 +69,7 @@ describe('open api generator', () => {
                 type: "object"
             },
             AnimalKind: {
+                $id: "#/components/schemas/AnimalKind",
                 enum: [
                     "dog",
                     "cat",
@@ -73,6 +78,7 @@ describe('open api generator', () => {
                 type: "string"
             },
             User: {
+                $id: "#/components/schemas/User",
                 properties: {
                     name: {
                         type: "string"
@@ -81,6 +87,7 @@ describe('open api generator', () => {
                 type: "object"
             },
             AnimalUpdate: {
+                $id: "#/components/schemas/AnimalUpdate",
                 allOf: [
                     {
                         $ref: "#/components/schemas/Registered"
@@ -99,6 +106,7 @@ describe('open api generator', () => {
                 ]
             },
             Registered: {
+                $id: "#/components/schemas/Registered",
                 properties: {
                     serialNumber: {
                         type: "string"
@@ -110,12 +118,15 @@ describe('open api generator', () => {
                 type: "object"
             },
             UserPatch: {
+                $id: "#/components/schemas/UserPatch",
                 type: "object"
             },
             AdjacentLicense: {
+                $id: "#/components/schemas/AdjacentLicense",
                 $ref: "#/components/schemas/AnimalLicense"
             },
             AnimalLicense: {
+                $id: "#/components/schemas/AnimalLicense",
                 properties: {
                     exp: {
                         type: "string"
@@ -133,6 +144,7 @@ describe('open api generator', () => {
                 type: "object"
             },
             AnimalMood: {
+                $id: "#/components/schemas/AnimalMood",
                 anyOf: [
                     {
                         properties: {

--- a/tests/paths.spec.ts
+++ b/tests/paths.spec.ts
@@ -20,6 +20,10 @@ describe('open api generator', () => {
         schema = JSON.parse(result.openApi.schema || "");
     });
 
+    it('sets OpenApi version', () => {
+        expect(schema.openapi).to.eq("3.1.0");
+    });
+
     it('generates schemas', () => {
         expect(schema.components?.schemas).to.deep.equalInAnyOrder({
             Account: {


### PR DESCRIPTION
## Issue Number: #18 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed

---

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Enhancement
- [ ] Other (please describe):

---

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- OpenApi version fixed to "3.0.3"
- `$id` property not allowed using current OpenApi version

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- OpenApi version fixed to "3.1.0"
- `$id` property set for all [Schema Objects](https://spec.openapis.org/oas/v3.1.0#schemaObject)

## Does this introduce a breaking change?

- [x] Yes (please describe): `$id` property is always set, even if an open api version is set in the base schema of `schemy-config.js`
- [ ] No

---

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->